### PR TITLE
Fix node-build install path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ commands:
           command: |
             git clone https://github.com/nodenv/node-build.git ../node-build
             sudo ../node-build/install.sh
-            sudo node-build $(cat .node-version) /usr/local
+            sudo node-build $(cat .node-version) ~/.local
             npm install
 
   save_all_caches:

--- a/Dockerfile.portal
+++ b/Dockerfile.portal
@@ -6,10 +6,11 @@ ENV DEBIAN_FRONTEND noninteractive
 
 COPY . /var/www/html
 
+ENV PATH "/usr/local/node/bin:$PATH"
 RUN apt-get update && apt-get install -y git unzip && \
     git clone https://github.com/nodenv/node-build.git && \
     ./node-build/install.sh && \
-    node-build $(cat /var/www/html/.node-version) /usr/local && \
+    node-build $(cat /var/www/html/.node-version) /usr/local/node && \
     rm /var/www/html/.node-version
 
 WORKDIR /var/www/html

--- a/build.xml
+++ b/build.xml
@@ -457,7 +457,7 @@
             <not><equals arg1="${checkLighthouse}" arg2="0"/></not>
             <then>
                 <echo msg="Installing lighthouse..."/>
-                <exec command="docker-compose exec php-fpm bash -c 'node-build $(cat .node-version) /usr/local'" dir="containers" checkreturn="true"/>
+                <exec command="docker-compose exec php-fpm bash -c 'node-build $(cat .node-version) /usr/local/node'" dir="containers" checkreturn="true"/>
                 <exec command="docker-compose exec php-fpm npm install -g @lhci/cli" dir="containers" checkreturn="true"/>
             </then>
         </if>

--- a/containers/php-fpm/Dockerfile
+++ b/containers/php-fpm/Dockerfile
@@ -24,6 +24,7 @@ RUN if [ ${INSTALL_XDEBUG} = true ]; then \
 COPY ./xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
 # dusk deps
+ENV PATH "/usr/local/node/bin:$PATH"
 ARG ENV=local
 ARG CHROME_BROWSER_CHANNEL=stable
 RUN if [ "env-${ENV}" = "env-local" ] || [ "env-${ENV}" = "env-testing" ]; then \


### PR DESCRIPTION
Un aggiornamento di node-build implica la cancellazione della directory indicata come path di installazione, quindi `/usr/local/` causava il fallimento delle build e altri potenziali problemi.