### PR TITLE
Fix tenant redirect when in users or websites page

### DIFF
--- a/app/Http/View/Composers/PublicAdministrationSelectorComposer.php
+++ b/app/Http/View/Composers/PublicAdministrationSelectorComposer.php
@@ -49,7 +49,7 @@ class PublicAdministrationSelectorComposer
         $lastRouteName = $lastRoute->getName();
         $lastRouteParameters = $lastRoute->parameters();
         $authUser = $this->request->user();
-        $targetRouteHasPublicAdministrationParam = $this->request->has('publicAdministration');
+        $targetRouteHasPublicAdministrationParam = array_key_exists('publicAdministration', $lastRouteParameters);
         $selectTenantUrl = route('publicAdministrations.select');
 
         if ($lastRoute->isFallback) {
@@ -76,7 +76,7 @@ class PublicAdministrationSelectorComposer
         }
 
         if ($authUser && $authUser->isA(UserRole::SUPER_ADMIN)) {
-            if ($targetRouteHasPublicAdministrationParam) {
+            if ($targetRouteHasPublicAdministrationParam && 'admin.' !== substr($targetRoute, 0, 6)) {
                 $targetRoute = 'admin.publicAdministration.' . $targetRoute;
             }
 

--- a/app/Http/View/Composers/PublicAdministrationSelectorComposer.php
+++ b/app/Http/View/Composers/PublicAdministrationSelectorComposer.php
@@ -47,43 +47,54 @@ class PublicAdministrationSelectorComposer
     {
         $lastRoute = $this->request->route();
         $lastRouteName = $lastRoute->getName();
+        $lastRouteParameters = $lastRoute->parameters();
         $authUser = $this->request->user();
+        $targetRouteHasPublicAdministrationParam = $this->request->has('publicAdministration');
+        $selectTenantUrl = route('publicAdministrations.select');
 
         if ($lastRoute->isFallback) {
             return;
         }
 
-        $selectTenantRoute = route('publicAdministrations.select');
-        switch ($lastRouteName) {
-            case 'admin.dashboard':
-            case 'home':
-                if ($authUser && $authUser->isA(UserRole::SUPER_ADMIN)) {
-                    $targetRoute = 'admin.publicAdministration.analytics';
-                } else {
-                    $targetRoute = 'analytics';
-                }
+        switch (true) {
+            case 'admin.dashboard' === $lastRouteName:
+            case 'home' === $lastRouteName:
+                $targetRoute = 'analytics';
                 $targetRouteHasPublicAdministrationParam = true;
+
+                break;
+            case array_key_exists('website', $lastRouteParameters):
+                $targetRoute = 'websites.index';
+
+                break;
+            case array_key_exists('user', $lastRouteParameters):
+                $targetRoute = 'users.index';
 
                 break;
             default:
                 $targetRoute = $lastRouteName;
-                $targetRouteHasPublicAdministrationParam = true;
         }
 
         if ($authUser && $authUser->isA(UserRole::SUPER_ADMIN)) {
+            if ($targetRouteHasPublicAdministrationParam) {
+                $targetRoute = 'admin.publicAdministration.' . $targetRoute;
+            }
+
             $publicAdministrationSelectorArray = PublicAdministration::all([
                 'ipa_code',
                 'name',
             ])->sortBy('name')->toArray();
+
             $publicAdministrationShowSelector = true;
-            $selectTenantRoute = route('admin.publicAdministrations.select');
+            $selectTenantUrl = route('admin.publicAdministrations.select');
         } elseif ($authUser) {
             $publicAdministrationSelectorArray = $authUser->publicAdministrations()->get()
-            ->map(function ($publicAdministration) {
-                return collect($publicAdministration->toArray())
-                    ->only(['id', 'ipa_code', 'name', 'url'])
-                    ->all();
-            })->sortBy('name')->values()->toArray();
+                ->map(function ($publicAdministration) {
+                    return collect($publicAdministration->toArray())
+                        ->only(['id', 'ipa_code', 'name', 'url'])
+                        ->all();
+                })->sortBy('name')->values()->toArray();
+
             $publicAdministrationShowSelector = count($publicAdministrationSelectorArray) > 1;
         } else {
             $publicAdministrationSelectorArray = [];
@@ -92,7 +103,7 @@ class PublicAdministrationSelectorComposer
 
         $view->with('publicAdministrationSelectorArray', $publicAdministrationSelectorArray);
         $view->with('publicAdministrationShowSelector', $publicAdministrationShowSelector);
-        $view->with('selectTenantRoute', $selectTenantRoute);
+        $view->with('selectTenantUrl', $selectTenantUrl);
         $view->with('targetRoute', $targetRoute);
         $view->with('targetRouteHasPublicAdministrationParam', $targetRouteHasPublicAdministrationParam);
     }

--- a/resources/views/layouts/includes/public_administration_selector.blade.php
+++ b/resources/views/layouts/includes/public_administration_selector.blade.php
@@ -1,5 +1,5 @@
 <div class="form-group m-0">
-    <form method="post" action="{{ $selectTenantRoute }}" novalidate class="pa-selector" >
+    <form method="post" action="{{ $selectTenantUrl }}" novalidate class="pa-selector" >
         @csrf
         <div class="input-group flex-nowrap">
             <div class="input-group-prepend">


### PR DESCRIPTION
Corregge un bug che mandava in crash l'applicazione quando si tentava di cambiare tenant da una pagina con route avente parametro `user` o `website`.