### PR TITLE
Add riuso key in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -58,6 +58,8 @@ intendedAudience:
   countries:
     - it
 it:
+  riuso:
+    codiceIPA: agid
   conforme:
     gdpr: true
     lineeGuidaDesign: true


### PR DESCRIPTION
This PR:
* adds the `riuso` key in the `it` one.

Thanks @pdavide 