### PR TITLE
Environments support cache clear

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -32,7 +32,6 @@ class Kernel extends ConsoleKernel
     }
 
     /**
-     *
      * Register the commands for the application.
      */
     protected function commands(): void

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,11 +27,12 @@ class Kernel extends ConsoleKernel
         $schedule->job(new ProcessPendingWebsites(true))->dailyAt('04:30')->onOneServer();
         $schedule->job(new MonitorWebsitesTracking())->daily()->onOneServer();
         $schedule->job(new PurgePendingInvitations())->dailyAt('03:30')->onOneServer();
-        // $publicPlaygroundResetTime = config('wai.reset_public_playground_hour', 23) . ':' . config('wai.reset_public_playground_minute', 30);
-        // $schedule->job(new ResetEnvironment())->weekly()->days(config('wai.reset_public_playground_day', 0))->at($publicPlaygroundResetTime)->onOneServer()->environments(['public-playground']);
+        $publicPlaygroundResetTime = config('wai.reset_public_playground_hour', 23) . ':' . config('wai.reset_public_playground_minute', 30);
+        $schedule->job(new ResetEnvironment())->weekly()->days(config('wai.reset_public_playground_day', 0))->at($publicPlaygroundResetTime)->onOneServer()->environments(['public-playground']);
     }
 
     /**
+     *
      * Register the commands for the application.
      */
     protected function commands(): void

--- a/app/Jobs/ResetEnvironment.php
+++ b/app/Jobs/ResetEnvironment.php
@@ -43,6 +43,9 @@ class ResetEnvironment implements ShouldQueue
             'command' => 'config:cache',
         ],
         [
+            'command' => 'cache:clear',
+        ],
+        [
             'command' => 'clear-compiled',
         ],
         [


### PR DESCRIPTION
Aggiunto il cache:clear ai commandi eseguiti durante il reset dell'ambiente.
Verificato che vengano puliti anche i database su Redis.

Rimane un problema legato a questa PR: si ottiene un errore eseguendo il commando cache:config come indicato nella #564 