### PR TITLE
Change param for PASSWORD_BCRYPT

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -156,7 +156,7 @@
         </php>
         <php function="password_hash" returnProperty="HASHED_MATOMO_ROOT_PASSWORD">
             <param value="${HASHED_MATOMO_ROOT_PASSWORD}"/>
-            <param value="1"/> <!-- PHP constant PASSWORD_BCRYPT is 1 -->
+            <param value="2y"/> <!-- PHP constant PASSWORD_BCRYPT is 2y -->
         </php>
         <if>
             <available file="containers/docker-compose.${env.APP_ENV}.yml" type="file" property="ignored"/>


### PR DESCRIPTION
Cambio del parametro in build.xml per PASSWORD_BCRYPT
Le costanti che identificano gli algoritmi di hashing non sono sono più interi ma stringhe.

https://github.com/php/php-src/blob/39a0854307cd63685b2fe158207727a2b8c06cd7/UPGRADING#L120-L130
